### PR TITLE
Add additional parament to Channel Followers response

### DIFF
--- a/src/main/java/com/mb3364/twitch/api/handlers/ChannelFollowsResponseHandler.java
+++ b/src/main/java/com/mb3364/twitch/api/handlers/ChannelFollowsResponseHandler.java
@@ -5,5 +5,5 @@ import com.mb3364.twitch.api.models.Follow;
 import java.util.List;
 
 public interface ChannelFollowsResponseHandler extends BaseFailureHandler {
-    void onSuccess(int total, List<Follow> follows);
+    void onSuccess(int total, List<Follow> follows, String cursor);
 }

--- a/src/main/java/com/mb3364/twitch/api/resources/ChannelsResource.java
+++ b/src/main/java/com/mb3364/twitch/api/resources/ChannelsResource.java
@@ -180,7 +180,7 @@ public class ChannelsResource extends AbstractResource {
             public void onSuccess(int statusCode, Map<String, List<String>> headers, String content) {
                 try {
                     ChannelFollows value = objectMapper.readValue(content, ChannelFollows.class);
-                    handler.onSuccess(value.getTotal(), value.getFollows());
+                    handler.onSuccess(value.getTotal(), value.getFollows(), value.getCursor());
                 } catch (IOException e) {
                     handler.onFailure(e);
                 }


### PR DESCRIPTION
Since "_link.next" not working anymore to requst next set of followers, we need cursor value for multu-page  requests-responses.

https://dev.twitch.tv/docs/v5/reference/channels#get-channel-followers 

P.S. in twitch v3 api "_link.next" also not working anymore.